### PR TITLE
feat: 엔티티 작성 및 JPA Auditing 설정 - 이동규

### DIFF
--- a/src/main/java/com/ssafy/solvedpick/SolvedPickApplication.java
+++ b/src/main/java/com/ssafy/solvedpick/SolvedPickApplication.java
@@ -2,7 +2,9 @@ package com.ssafy.solvedpick;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class SolvedPickApplication {
 

--- a/src/main/java/com/ssafy/solvedpick/avatars/domain/Avatar.java
+++ b/src/main/java/com/ssafy/solvedpick/avatars/domain/Avatar.java
@@ -1,0 +1,29 @@
+package com.ssafy.solvedpick.avatars.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "avatars")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+public class Avatar {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "avatar_id")
+    private Long id;
+
+    @Column(unique = true, nullable = false, length = 50)
+    private String title;
+
+    @Column(nullable = false)
+    private int grade;
+
+    @OneToMany(mappedBy = "avatar")
+    private List<OwnedAvatar> avatars = new ArrayList<>();
+}

--- a/src/main/java/com/ssafy/solvedpick/avatars/domain/Avatar.java
+++ b/src/main/java/com/ssafy/solvedpick/avatars/domain/Avatar.java
@@ -15,7 +15,7 @@ import java.util.List;
 public class Avatar {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "avatar_id")
+    @Column(name = "avatar_id", columnDefinition = "INT UNSIGNED")
     private Long id;
 
     @Column(unique = true, nullable = false, length = 50)

--- a/src/main/java/com/ssafy/solvedpick/avatars/domain/Avatar.java
+++ b/src/main/java/com/ssafy/solvedpick/avatars/domain/Avatar.java
@@ -24,6 +24,6 @@ public class Avatar {
     @Column(nullable = false)
     private int grade;
 
-    @OneToMany(mappedBy = "avatar")
+    @OneToMany(mappedBy = "avatar", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<OwnedAvatar> avatars = new ArrayList<>();
 }

--- a/src/main/java/com/ssafy/solvedpick/avatars/domain/OwnedAvatar.java
+++ b/src/main/java/com/ssafy/solvedpick/avatars/domain/OwnedAvatar.java
@@ -19,15 +19,15 @@ public class OwnedAvatar {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "owned_avatar_id")
+    @Column(name = "owned_avatar_id", columnDefinition = "INT UNSIGNED")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
+    @JoinColumn(name = "user_id", nullable = false, columnDefinition = "INT UNSIGNED")
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "avatar_id", nullable = false)
+    @JoinColumn(name = "avatar_id", nullable = false, columnDefinition = "INT UNSIGNED")
     private Avatar avatar;
 
     @Column(nullable = false)

--- a/src/main/java/com/ssafy/solvedpick/avatars/domain/OwnedAvatar.java
+++ b/src/main/java/com/ssafy/solvedpick/avatars/domain/OwnedAvatar.java
@@ -1,0 +1,40 @@
+package com.ssafy.solvedpick.avatars.domain;
+
+import com.ssafy.solvedpick.members.domain.Member;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "owned_avatars")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@EntityListeners(AuditingEntityListener.class)
+public class OwnedAvatar {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "owned_avatar_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "avatar_id", nullable = false)
+    private Avatar avatar;
+
+    @Column(nullable = false)
+    private boolean visible = false;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime acquiredAt;
+
+}

--- a/src/main/java/com/ssafy/solvedpick/members/domain/Member.java
+++ b/src/main/java/com/ssafy/solvedpick/members/domain/Member.java
@@ -21,7 +21,7 @@ public class Member {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "user_id")
+    @Column(name = "user_id", columnDefinition = "INT UNSIGNED")
     private Long id;
 
     @Column(unique = true, nullable = false, length = 30)

--- a/src/main/java/com/ssafy/solvedpick/members/domain/Member.java
+++ b/src/main/java/com/ssafy/solvedpick/members/domain/Member.java
@@ -1,0 +1,46 @@
+package com.ssafy.solvedpick.members.domain;
+
+import com.ssafy.solvedpick.avatars.domain.OwnedAvatar;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Table(name = "members")
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long id;
+
+    @Column(unique = true, nullable = false, length = 30)
+    private String username;
+
+    @Column(nullable = false, length = 72)
+    private String password;
+
+    @Column
+    private int point = 0;
+
+    @Column
+    private boolean verified = false;
+
+    @CreatedDate
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @OneToMany(mappedBy = "member")
+    private List<OwnedAvatar> avatars = new ArrayList<>();
+
+}

--- a/src/main/java/com/ssafy/solvedpick/members/domain/Member.java
+++ b/src/main/java/com/ssafy/solvedpick/members/domain/Member.java
@@ -40,7 +40,7 @@ public class Member {
     @Column(name = "created_at")
     private LocalDateTime createdAt;
 
-    @OneToMany(mappedBy = "member")
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<OwnedAvatar> avatars = new ArrayList<>();
 
 }


### PR DESCRIPTION
## 💬 Issue Number

## 📝 작업 내용
feat: Entity 구조 설정
- Member, Avatar, OwnedAvatar Entity 작성
- 연관관계 매핑 (@OneToMany, @ManyToOne)
- 각 필드 제약조건 설정

chore: JPA Auditing 설정 추가
- createdAt, acquiredAt 필드 자동 생성 시간 설정
- @EnableJpaAuditing 설정

fix: Entity 타입 매핑 수정
- INT UNSIGNED와의 호환성을 위한 columnDefinition 추가
- ID 필드 타입 매핑 불일치 해결

feat: Entity 연관관계 영속성 설정
- cascade = CascadeType.ALL 설정
- orphanRemoval = true 설정
- FetchType.LAZY 설정으로 N+1 문제 방지
## 📷 Screenshots

> 작업 결과물

## 🚀 학습에 도움을 줄만한 자료
[JPA Auditing 기능이란?](https://webcoding-start.tistory.com/53)
[JPA @OneToMany, @ManyToOne으로 연관관계 관리하기](https://velog.io/@goniieee/JPA-OneToMany-ManyToOne%EC%9C%BC%EB%A1%9C-%EC%97%B0%EA%B4%80%EA%B4%80%EA%B3%84-%EA%B4%80%EB%A6%AC%ED%95%98%EA%B8%B0)
[@ManyToOne, @OneToMany 이해하기](https://soojong.tistory.com/entry/JPA-ManyToOne-OneToMany-%EC%9D%B4%ED%95%B4%ED%95%98%EA%B8%B0)
[영속성 전이 Cascade란?](https://willseungh0.tistory.com/67)
[즉시로딩(EAGER)과 지연로딩(LAZY)(왜 LAZY 로딩을 써야할까?)](https://velog.io/@jin0849/JPA-%EC%A6%89%EC%8B%9C%EB%A1%9C%EB%94%A9EAGER%EA%B3%BC-%EC%A7%80%EC%97%B0%EB%A1%9C%EB%94%A9LAZY)
## 📒 Remarks
처음 Long Type으로 member와 avatar의 pk를 잡았더니 오류가 발생했습니다. DB에서는 INT UNSIGNED를 사용하고 있는데 JPA 엔티티에서는 Long을 사용했기에 충돌이 발생했습니다. 이를 해결하기 위해 Entity의 ID 필드들을 columnDefinition을 통해 정의해주었습니다. 이는 해당 필드가 Foreign Key로 사용되고 있기 때문에 발생한 것으로 Foreign Key에 사용되지 않는다면 `값 범위가 호환되는 한` 따로 지정하지 않아도 괜찮습니다. Foreign Key는 참조 무결성을 위해 타입이 정확히 일치해야 하므로 이와 관련해서는 참조 무결성으로 검색해보면 좋을 것 같습니다.
또한 N+1문제에 관해서도 각자 찾아보면 좋을 것 같습니다. 