### PR TITLE
feat: 사용자 아바타 조회 기능 구현 - 김지영

### DIFF
--- a/src/main/java/com/ssafy/solvedpick/avatars/domain/Avatar.java
+++ b/src/main/java/com/ssafy/solvedpick/avatars/domain/Avatar.java
@@ -1,5 +1,6 @@
 package com.ssafy.solvedpick.avatars.domain;
 
+import com.ssafy.solvedpick.ownedavatar.domain.OwnedAvatar;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -7,11 +8,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
-@Table(name = "avatars")
 @Getter
+@Builder
+@Table(name = "avatars")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
-@Builder
 public class Avatar {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/ssafy/solvedpick/avatars/repository/OwnedAvatarRepository.java
+++ b/src/main/java/com/ssafy/solvedpick/avatars/repository/OwnedAvatarRepository.java
@@ -1,9 +1,0 @@
-package com.ssafy.solvedpick.avatars.repository;
-
-import com.ssafy.solvedpick.avatars.domain.OwnedAvatar;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
-@Repository
-public interface OwnedAvatarRepository extends JpaRepository<OwnedAvatar, Long> {
-}

--- a/src/main/java/com/ssafy/solvedpick/gacha/service/GachaService.java
+++ b/src/main/java/com/ssafy/solvedpick/gacha/service/GachaService.java
@@ -2,10 +2,10 @@ package com.ssafy.solvedpick.gacha.service;
 
 import com.ssafy.solvedpick.avatars.domain.Avatar;
 import com.ssafy.solvedpick.avatars.domain.Grade;
-import com.ssafy.solvedpick.avatars.domain.OwnedAvatar;
+import com.ssafy.solvedpick.ownedavatar.domain.OwnedAvatar;
 import com.ssafy.solvedpick.avatars.dto.DrawAvatarDto;
 import com.ssafy.solvedpick.avatars.repository.AvatarRepository;
-import com.ssafy.solvedpick.avatars.repository.OwnedAvatarRepository;
+import com.ssafy.solvedpick.ownedavatar.repository.OwnedAvatarRepository;
 import com.ssafy.solvedpick.gacha.dto.DrawResponse;
 import com.ssafy.solvedpick.members.domain.Member;
 import com.ssafy.solvedpick.members.repository.MemberRepository;
@@ -19,6 +19,7 @@ import java.util.Random;
 @Service
 @RequiredArgsConstructor
 public class GachaService {
+
 //    임시 코스트
     private static final int DRAW_COST = 1000;
 

--- a/src/main/java/com/ssafy/solvedpick/members/domain/Member.java
+++ b/src/main/java/com/ssafy/solvedpick/members/domain/Member.java
@@ -1,6 +1,6 @@
 package com.ssafy.solvedpick.members.domain;
 
-import com.ssafy.solvedpick.avatars.domain.OwnedAvatar;
+import com.ssafy.solvedpick.ownedavatar.domain.OwnedAvatar;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;

--- a/src/main/java/com/ssafy/solvedpick/ownedavatar/domain/OwnedAvatar.java
+++ b/src/main/java/com/ssafy/solvedpick/ownedavatar/domain/OwnedAvatar.java
@@ -1,5 +1,6 @@
-package com.ssafy.solvedpick.avatars.domain;
+package com.ssafy.solvedpick.ownedavatar.domain;
 
+import com.ssafy.solvedpick.avatars.domain.Avatar;
 import com.ssafy.solvedpick.members.domain.Member;
 import jakarta.persistence.*;
 import lombok.*;
@@ -9,12 +10,12 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "owned_avatars")
 @Getter
+@Builder
+@Table(name = "owned_avatars")
+@EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
-@Builder
-@EntityListeners(AuditingEntityListener.class)
 public class OwnedAvatar {
 
     @Id
@@ -30,11 +31,11 @@ public class OwnedAvatar {
     @JoinColumn(name = "avatar_id", nullable = false, columnDefinition = "INT UNSIGNED")
     private Avatar avatar;
 
+    @Builder.Default
     @Column(nullable = false)
     private boolean visible = false;
 
     @CreatedDate
     @Column(updatable = false)
     private LocalDateTime acquiredAt;
-
 }

--- a/src/main/java/com/ssafy/solvedpick/ownedavatar/dto/MemberAvatarResponseDTO.java
+++ b/src/main/java/com/ssafy/solvedpick/ownedavatar/dto/MemberAvatarResponseDTO.java
@@ -1,0 +1,14 @@
+package com.ssafy.solvedpick.ownedavatar.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberAvatarResponseDTO {
+
+    private List<OwnedAvatarDTO> avatars;
+}

--- a/src/main/java/com/ssafy/solvedpick/ownedavatar/dto/OwnedAvatarDTO.java
+++ b/src/main/java/com/ssafy/solvedpick/ownedavatar/dto/OwnedAvatarDTO.java
@@ -1,0 +1,16 @@
+package com.ssafy.solvedpick.ownedavatar.dto;
+
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OwnedAvatarDTO {
+
+    private Long ownedAvatarId;
+    private String name;
+    private String rarity;
+    private double dropRate;
+    private boolean visible;
+}

--- a/src/main/java/com/ssafy/solvedpick/ownedavatar/presentation/OwnedAvatarController.java
+++ b/src/main/java/com/ssafy/solvedpick/ownedavatar/presentation/OwnedAvatarController.java
@@ -1,0 +1,32 @@
+package com.ssafy.solvedpick.ownedavatar.presentation;
+
+import com.ssafy.solvedpick.ownedavatar.dto.MemberAvatarResponseDTO;
+import com.ssafy.solvedpick.ownedavatar.dto.OwnedAvatarDTO;
+import com.ssafy.solvedpick.ownedavatar.service.OwnedAvatarService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/my/avatar")
+public class OwnedAvatarController {
+
+    private final OwnedAvatarService ownedAvatarService;
+
+    // TODO: JWT 기능의 부재로 현재는 Authorization header
+    @GetMapping()
+    public ResponseEntity<?> getMemberAvatar(@RequestHeader(value = "Authorization") Long memberId) {
+        List<OwnedAvatarDTO> avatars = ownedAvatarService.getOwnedAvatars(memberId);
+        MemberAvatarResponseDTO result = MemberAvatarResponseDTO.builder()
+                .avatars(avatars)
+                .build();
+
+        return ResponseEntity.ok().body(result);
+    }
+}

--- a/src/main/java/com/ssafy/solvedpick/ownedavatar/repository/OwnedAvatarRepository.java
+++ b/src/main/java/com/ssafy/solvedpick/ownedavatar/repository/OwnedAvatarRepository.java
@@ -1,0 +1,18 @@
+package com.ssafy.solvedpick.ownedavatar.repository;
+
+import com.ssafy.solvedpick.ownedavatar.domain.OwnedAvatar;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface OwnedAvatarRepository extends JpaRepository<OwnedAvatar, Long> {
+
+    @Query("SELECT a " +
+            "FROM OwnedAvatar a " +
+            "LEFT JOIN FETCH a.member m " +
+            "LEFT JOIN FETCH a.avatar " +
+            "WHERE m.id = :memberId")
+    List<OwnedAvatar> findAllByMemberId(@Param("memberId") Long memberId);
+}

--- a/src/main/java/com/ssafy/solvedpick/ownedavatar/service/OwnedAvatarService.java
+++ b/src/main/java/com/ssafy/solvedpick/ownedavatar/service/OwnedAvatarService.java
@@ -1,0 +1,10 @@
+package com.ssafy.solvedpick.ownedavatar.service;
+
+import com.ssafy.solvedpick.ownedavatar.dto.OwnedAvatarDTO;
+
+import java.util.List;
+
+public interface OwnedAvatarService {
+
+    List<OwnedAvatarDTO> getOwnedAvatars(Long memberId);
+}

--- a/src/main/java/com/ssafy/solvedpick/ownedavatar/service/impl/OwnedAvatarServiceImpl.java
+++ b/src/main/java/com/ssafy/solvedpick/ownedavatar/service/impl/OwnedAvatarServiceImpl.java
@@ -1,0 +1,33 @@
+package com.ssafy.solvedpick.ownedavatar.service.impl;
+
+import com.ssafy.solvedpick.avatars.domain.Grade;
+import com.ssafy.solvedpick.ownedavatar.dto.OwnedAvatarDTO;
+import com.ssafy.solvedpick.ownedavatar.repository.OwnedAvatarRepository;
+import com.ssafy.solvedpick.ownedavatar.service.OwnedAvatarService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class OwnedAvatarServiceImpl implements OwnedAvatarService {
+
+    private final OwnedAvatarRepository ownedAvatarRepository;
+
+    @Override
+    public List<OwnedAvatarDTO> getOwnedAvatars(Long memberId) {
+        return ownedAvatarRepository.findAllByMemberId(memberId)
+                .stream()
+                .map(ownedAvatar -> OwnedAvatarDTO.builder()
+                        .visible(ownedAvatar.isVisible())
+                        .ownedAvatarId(ownedAvatar.getId())
+                        .name(ownedAvatar.getAvatar().getTitle())
+                        .rarity(Grade.fromValue(ownedAvatar.getAvatar().getGrade()).name())
+                        .dropRate(Grade.fromValue(ownedAvatar.getAvatar().getGrade()).getProbability())
+                        .build())
+                .toList();
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용
- 사용자의 id를 기준으로 보유하고 있는 캐릭터를 반환합니다.
- 현재 JWT의 부재로 `Authorization` header에 직접 `member_id`를 넣어서 요청합니다.

## 📷 Screenshots

> 작업 결과물
![image](https://github.com/user-attachments/assets/9e3426e1-cf9f-4b0a-b1e2-51814e2d84b5)
